### PR TITLE
Fix typos

### DIFF
--- a/contracts/mock/AVSDirectoryMock.sol
+++ b/contracts/mock/AVSDirectoryMock.sol
@@ -108,7 +108,7 @@ contract AVSDirectoryMock is IAVSDirectory {
     }
 
     /**
-     * @notice Called by an avs to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     * @notice Called by an avs to emit an `AVSMetadataURIUpdated` event indicating the information has been updated.
      * @param metadataURI The URI for metadata associated with an avs
      */
     function updateAVSMetadataURI(string calldata metadataURI) external {

--- a/contracts/mock/optimism/L2OutputOracle.sol
+++ b/contracts/mock/optimism/L2OutputOracle.sol
@@ -75,7 +75,7 @@ contract L2OutputOracle is Initializable {
     ///         order to be accepted. This function may only be called by the Proposer.
     /// @param _outputRoot    The L2 output of the checkpoint block.
     /// @param _l2BlockNumber The L2 block number that resulted in _outputRoot.
-    /// @param _l1BlockHash   A block hash which must be included in the current chain.
+    /// @param _l1BlockHash   A block hash that must be included in the current chain.
     /// @param _l1BlockNumber The block number with the specified block hash.
     function proposeL2Output(bytes32 _outputRoot, uint256 _l2BlockNumber, bytes32 _l1BlockHash, uint256 _l1BlockNumber)
         external
@@ -183,7 +183,7 @@ contract L2OutputOracle is Initializable {
     }
     //include
     /// @notice Returns the block number of the latest submitted L2 output proposal.
-    ///         If no proposals been submitted yet then this function will return the starting
+    ///         If no proposals have been submitted yet then this function will return the starting
     ///         block number.
     /// @return Latest submitted L2 block number.
 

--- a/contracts/protocol/EvidenceVerifier.sol
+++ b/contracts/protocol/EvidenceVerifier.sol
@@ -59,10 +59,10 @@ contract EvidenceVerifier is Initializable, OwnableUpgradeable, IEvidenceVerifie
 
     /// upload the evidence to punish the operator.
     function uploadEvidence(Evidence calldata evidence) external {
-        // check the operator is registered or not
+        // check whether the operator is registered or not
         // TODO
 
-        // check the operator is slashed or not
+        // check whether the operator is slashed or not
 
         require(checkCommitSignature(evidence), "The commit signature is not correct");
 
@@ -120,7 +120,7 @@ contract EvidenceVerifier is Initializable, OwnableUpgradeable, IEvidenceVerifie
         return (sigVerify);
     }
 
-    // Slashing condition.  Returns veriifcation of chain's current committee root at a given block.
+    // Slashing condition.  Returns verification of chain's current committee root at a given block.
     function _checkCommitteeRoots(
         bytes32 correctCurrentCommitteeRoot,
         bytes32 currentCommitteeRoot,

--- a/script/localnet/M1_Deploy.s.sol
+++ b/script/localnet/M1_Deploy.s.sol
@@ -488,7 +488,7 @@ contract Deployer_M1 is Script, Test {
         // uint256 SLASHER_INIT_PAUSED_STATUS = type(uint256).max;
         // // pause *everything*
         // uint256 DELEGATION_INIT_PAUSED_STATUS = type(uint256).max;
-        // // pause *all of the proof-related functionality* (everything that can be paused other than creation of EigenPods)
+        // // pause *all of the proof-related functionality* (everything that can be paused other than the creation of EigenPods)
         // uint256 EIGENPOD_MANAGER_INIT_PAUSED_STATUS = (2**1) + (2**2) + (2**3) + (2**4); /* = 30 */
         // // pause *nothing*
         // uint256 DELAYED_WITHDRAWAL_ROUTER_INIT_PAUSED_STATUS = 0;

--- a/test/foundry/LagrangeDeployer.t.sol
+++ b/test/foundry/LagrangeDeployer.t.sol
@@ -57,7 +57,7 @@ contract LagrangeDeployer is Test {
         address sender = vm.addr(1);
         vm.startPrank(sender);
 
-        // deploy proxy admin for ability to upgrade proxy contracts
+        // deploy proxy admin for the ability to upgrade proxy contracts
         proxyAdmin = new ProxyAdmin();
         token = new WETH9();
 
@@ -140,7 +140,7 @@ contract LagrangeDeployer is Test {
         multipliers[0] = IVoteWeigher.TokenMultiplier(address(token), 1e9);
         voteWeigher.addQuorumMultiplier(0, multipliers);
 
-        // add tokens to whitelist
+        // add tokens to the whitelist
         address[] memory tokens = new address[](1);
         tokens[0] = address(token);
         stakeManager.addTokensToWhitelist(tokens);

--- a/test/foundry/RegisterOperator.t.sol
+++ b/test/foundry/RegisterOperator.t.sol
@@ -59,7 +59,7 @@ contract RegisterOperatorTest is LagrangeDeployer {
         // deregister operator
         lagrangeService.deregister();
 
-        // withdraw tokens from stake manager
+        // withdraw tokens from the stake manager
         vm.roll(START_EPOCH + EPOCH_PERIOD * 2);
         vm.expectRevert("Stake is locked");
         stakeManager.withdraw(IERC20(address(token)), amount);
@@ -105,7 +105,7 @@ contract RegisterOperatorTest is LagrangeDeployer {
         vm.roll(START_EPOCH + EPOCH_PERIOD - FREEZE_DURATION);
         lagrangeService.register(operator, blsPubKeys, operatorSignature);
 
-        // it should fail because the committee is in freeze period
+        // it should fail because the committee is in a freeze period
         vm.roll(START_EPOCH + EPOCH_PERIOD - FREEZE_DURATION + 1);
         vm.expectRevert("The dedicated chain is locked.");
         lagrangeService.subscribe(CHAIN_ID);
@@ -143,7 +143,7 @@ contract RegisterOperatorTest is LagrangeDeployer {
 
         // unsubscribe and subscribe operator
         lagrangeService.unsubscribe(CHAIN_ID);
-        vm.expectRevert("The dedciated chain is while unsubscribing.");
+        vm.expectRevert("The dedicated chain is while unsubscribing.");
         lagrangeService.subscribe(CHAIN_ID);
         vm.roll(START_EPOCH + EPOCH_PERIOD * 2 + 1);
         lagrangeService.subscribe(CHAIN_ID);


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Best regards.
